### PR TITLE
Add branding customization option

### DIFF
--- a/packages/server/src/services/settings/index.ts
+++ b/packages/server/src/services/settings/index.ts
@@ -2,25 +2,32 @@
 
 import { Platform } from '../../Interface'
 import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
+import { Variable } from '../../database/entities/Variable'
 
 const getSettings = async () => {
     try {
         const appServer = getRunningExpressApp()
         const platformType = appServer.identityManager.getPlatformType()
 
+        const brandingLogo = await appServer.AppDataSource.getRepository(Variable).findOne({
+            where: { name: 'BRANDING_LOGO' }
+        })
+
+        const baseSettings = { BRANDING_LOGO: brandingLogo?.value }
+
         switch (platformType) {
             case Platform.ENTERPRISE: {
                 if (!appServer.identityManager.isLicenseValid()) {
                     return {}
                 } else {
-                    return { PLATFORM_TYPE: Platform.ENTERPRISE }
+                    return { ...baseSettings, PLATFORM_TYPE: Platform.ENTERPRISE }
                 }
             }
             case Platform.CLOUD: {
-                return { PLATFORM_TYPE: Platform.CLOUD }
+                return { ...baseSettings, PLATFORM_TYPE: Platform.CLOUD }
             }
             default: {
-                return { PLATFORM_TYPE: Platform.OPEN_SOURCE }
+                return { ...baseSettings, PLATFORM_TYPE: Platform.OPEN_SOURCE }
             }
         }
     } catch (error) {

--- a/packages/ui/src/menu-items/dashboard.js
+++ b/packages/ui/src/menu-items/dashboard.js
@@ -284,6 +284,15 @@ const dashboard = {
                     icon: icons.IconSettings,
                     breadcrumbs: true,
                     display: 'feat:account'
+                },
+                {
+                    id: 'branding',
+                    title: 'Branding',
+                    type: 'item',
+                    url: '/branding',
+                    icon: icons.IconSettings,
+                    breadcrumbs: true,
+                    display: 'feat:account'
                 }
             ]
         }

--- a/packages/ui/src/routes/MainRoutes.jsx
+++ b/packages/ui/src/routes/MainRoutes.jsx
@@ -50,6 +50,7 @@ const Evaluators = Loadable(lazy(() => import('@/views/evaluators')))
 
 // account routing
 const Account = Loadable(lazy(() => import('@/views/account')))
+const Branding = Loadable(lazy(() => import('@/views/branding')))
 const UserProfile = Loadable(lazy(() => import('@/views/account/UserProfile')))
 
 // files routing
@@ -297,6 +298,14 @@ const MainRoutes = {
             element: (
                 <RequireAuth display={'feat:account'}>
                     <Account />
+                </RequireAuth>
+            )
+        },
+        {
+            path: '/branding',
+            element: (
+                <RequireAuth display={'feat:account'}>
+                    <Branding />
                 </RequireAuth>
             )
         },

--- a/packages/ui/src/ui-component/extended/Logo.jsx
+++ b/packages/ui/src/ui-component/extended/Logo.jsx
@@ -1,5 +1,6 @@
 import logo from '@/assets/images/flowise_white.svg'
 import logoDark from '@/assets/images/flowise_dark.svg'
+import { useConfig } from '@/store/context/ConfigContext'
 
 import { useSelector } from 'react-redux'
 
@@ -7,12 +8,13 @@ import { useSelector } from 'react-redux'
 
 const Logo = () => {
     const customization = useSelector((state) => state.customization)
+    const { config } = useConfig()
 
     return (
         <div style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', marginLeft: '10px' }}>
             <img
                 style={{ objectFit: 'contain', height: 'auto', width: 150 }}
-                src={customization.isDarkMode ? logoDark : logo}
+                src={config.BRANDING_LOGO || (customization.isDarkMode ? logoDark : logo)}
                 alt='Flowise'
             />
         </div>

--- a/packages/ui/src/views/branding/index.jsx
+++ b/packages/ui/src/views/branding/index.jsx
@@ -1,0 +1,110 @@
+import { useState, useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { Button, Box, Typography } from '@mui/material'
+
+import MainCard from '@/ui-component/cards/MainCard'
+import ViewHeader from '@/layout/MainLayout/ViewHeader'
+import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackbarAction } from '@/store/actions'
+
+import variablesApi from '@/api/variables'
+import useApi from '@/hooks/useApi'
+import useNotifier from '@/utils/useNotifier'
+
+import { IconX } from '@tabler/icons-react'
+
+const Branding = () => {
+    const dispatch = useDispatch()
+    useNotifier()
+
+    const enqueueSnackbar = (...args) => dispatch(enqueueSnackbarAction(...args))
+    const closeSnackbar = (...args) => dispatch(closeSnackbarAction(...args))
+
+    const [logo, setLogo] = useState('')
+    const [brandingVar, setBrandingVar] = useState(null)
+
+    const getAllVariablesApi = useApi(variablesApi.getAllVariables)
+
+    useEffect(() => {
+        getAllVariablesApi.request()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
+        if (getAllVariablesApi.data) {
+            const found = getAllVariablesApi.data.data.find((v) => v.name === 'BRANDING_LOGO')
+            if (found) {
+                setBrandingVar(found)
+                setLogo(found.value)
+            }
+        }
+    }, [getAllVariablesApi.data])
+
+    const handleFileChange = (e) => {
+        if (!e.target.files || !e.target.files[0]) return
+        const file = e.target.files[0]
+        const reader = new FileReader()
+        reader.onload = (evt) => {
+            if (!evt?.target?.result) return
+            setLogo(evt.target.result)
+        }
+        reader.readAsDataURL(file)
+    }
+
+    const saveBranding = async () => {
+        try {
+            const obj = { name: 'BRANDING_LOGO', value: logo, type: 'static' }
+            if (brandingVar) {
+                await variablesApi.updateVariable(brandingVar.id, obj)
+            } else {
+                await variablesApi.createVariable(obj)
+            }
+            enqueueSnackbar({
+                message: 'Branding saved',
+                options: {
+                    key: new Date().getTime() + Math.random(),
+                    variant: 'success',
+                    action: (key) => (
+                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
+                            <IconX />
+                        </Button>
+                    )
+                }
+            })
+        } catch (error) {
+            enqueueSnackbar({
+                message: `Failed to save branding: ${error.response?.data?.message || error.message}`,
+                options: {
+                    key: new Date().getTime() + Math.random(),
+                    variant: 'error',
+                    persist: true,
+                    action: (key) => (
+                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
+                            <IconX />
+                        </Button>
+                    )
+                }
+            })
+        }
+    }
+
+    return (
+        <MainCard>
+            <ViewHeader title='Branding' description='Upload a custom logo for the application' />
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <input type='file' accept='image/*' onChange={handleFileChange} />
+                {logo && (
+                    <Box sx={{ mt: 1 }}>
+                        <Typography variant='body2'>Preview:</Typography>
+                        <img src={logo} alt='branding logo' style={{ height: 60, marginTop: 8 }} />
+                    </Box>
+                )}
+                <Button variant='contained' sx={{ width: 'fit-content' }} onClick={saveBranding} disabled={!logo}>
+                    Save
+                </Button>
+            </Box>
+        </MainCard>
+    )
+}
+
+export default Branding


### PR DESCRIPTION
## Summary
- allow server to return optional branding logo value
- add Branding menu and route in the UI
- display uploaded branding logo in app header
- create Branding page to upload custom logo

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f354e6824832797bc93abd98cb647