### PR TITLE
Add open-source branding page

### DIFF
--- a/packages/ui/src/menu-items/dashboard.js
+++ b/packages/ui/src/menu-items/dashboard.js
@@ -291,8 +291,7 @@ const dashboard = {
                     type: 'item',
                     url: '/branding',
                     icon: icons.IconSettings,
-                    breadcrumbs: true,
-                    display: 'feat:account'
+                    breadcrumbs: true
                 }
             ]
         }

--- a/packages/ui/src/routes/MainRoutes.jsx
+++ b/packages/ui/src/routes/MainRoutes.jsx
@@ -304,7 +304,7 @@ const MainRoutes = {
         {
             path: '/branding',
             element: (
-                <RequireAuth display={'feat:account'}>
+                <RequireAuth>
                     <Branding />
                 </RequireAuth>
             )


### PR DESCRIPTION
## Summary
- expose Branding menu item and route to all deployments
- allow uploading a logo without feature flag restrictions

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3d7cac2883279d58adcab88e31ae