### PR TITLE
Fix branding page permissions

### DIFF
--- a/packages/ui/src/menu-items/dashboard.js
+++ b/packages/ui/src/menu-items/dashboard.js
@@ -291,7 +291,8 @@ const dashboard = {
                     type: 'item',
                     url: '/branding',
                     icon: icons.IconSettings,
-                    breadcrumbs: true
+                    breadcrumbs: true,
+                    permission: 'variables:view'
                 }
             ]
         }

--- a/packages/ui/src/routes/MainRoutes.jsx
+++ b/packages/ui/src/routes/MainRoutes.jsx
@@ -304,7 +304,7 @@ const MainRoutes = {
         {
             path: '/branding',
             element: (
-                <RequireAuth>
+                <RequireAuth permission={'variables:view'}>
                     <Branding />
                 </RequireAuth>
             )


### PR DESCRIPTION
## Summary
- restrict Branding menu item and route to users with the `variables:view` permission

## Testing
- `pnpm install` *(fails: network access blocked)*
- `pnpm lint` *(fails: could not find plugin due to missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_687f51e7415c8327a736a768d0d662ad