### PR TITLE
Fix branding page variable load

### DIFF
--- a/packages/ui/src/views/branding/index.jsx
+++ b/packages/ui/src/views/branding/index.jsx
@@ -32,7 +32,8 @@ const Branding = () => {
 
     useEffect(() => {
         if (getAllVariablesApi.data) {
-            const found = getAllVariablesApi.data.data.find((v) => v.name === 'BRANDING_LOGO')
+            const variables = Array.isArray(getAllVariablesApi.data) ? getAllVariablesApi.data : getAllVariablesApi.data.data
+            const found = variables?.find((v) => v.name === 'BRANDING_LOGO')
             if (found) {
                 setBrandingVar(found)
                 setLogo(found.value)


### PR DESCRIPTION
## Summary
- fix branding page when variables endpoint returns array instead of object

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5887df90832790866ef3705818e9