### PR TITLE
Add footer branding options

### DIFF
--- a/packages/server/src/services/settings/index.ts
+++ b/packages/server/src/services/settings/index.ts
@@ -9,11 +9,23 @@ const getSettings = async () => {
         const appServer = getRunningExpressApp()
         const platformType = appServer.identityManager.getPlatformType()
 
-        const brandingLogo = await appServer.AppDataSource.getRepository(Variable).findOne({
+        const variableRepo = appServer.AppDataSource.getRepository(Variable)
+
+        const brandingLogo = await variableRepo.findOne({
             where: { name: 'BRANDING_LOGO' }
         })
+        const brandingFooterText = await variableRepo.findOne({
+            where: { name: 'BRANDING_FOOTER_TEXT' }
+        })
+        const brandingFooterLink = await variableRepo.findOne({
+            where: { name: 'BRANDING_FOOTER_LINK' }
+        })
 
-        const baseSettings = { BRANDING_LOGO: brandingLogo?.value }
+        const baseSettings = {
+            BRANDING_LOGO: brandingLogo?.value,
+            BRANDING_FOOTER_TEXT: brandingFooterText?.value,
+            BRANDING_FOOTER_LINK: brandingFooterLink?.value
+        }
 
         switch (platformType) {
             case Platform.ENTERPRISE: {

--- a/packages/ui/src/views/branding/index.jsx
+++ b/packages/ui/src/views/branding/index.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 
-import { Button, Box, Typography } from '@mui/material'
+import { Button, Box, Typography, OutlinedInput } from '@mui/material'
 
 import MainCard from '@/ui-component/cards/MainCard'
 import ViewHeader from '@/layout/MainLayout/ViewHeader'
@@ -22,6 +22,10 @@ const Branding = () => {
 
     const [logo, setLogo] = useState('')
     const [brandingVar, setBrandingVar] = useState(null)
+    const [footerText, setFooterText] = useState('')
+    const [footerLink, setFooterLink] = useState('')
+    const [brandingFooterTextVar, setBrandingFooterTextVar] = useState(null)
+    const [brandingFooterLinkVar, setBrandingFooterLinkVar] = useState(null)
 
     const getAllVariablesApi = useApi(variablesApi.getAllVariables)
 
@@ -33,10 +37,20 @@ const Branding = () => {
     useEffect(() => {
         if (getAllVariablesApi.data) {
             const variables = Array.isArray(getAllVariablesApi.data) ? getAllVariablesApi.data : getAllVariablesApi.data.data
-            const found = variables?.find((v) => v.name === 'BRANDING_LOGO')
-            if (found) {
-                setBrandingVar(found)
-                setLogo(found.value)
+            const foundLogo = variables?.find((v) => v.name === 'BRANDING_LOGO')
+            if (foundLogo) {
+                setBrandingVar(foundLogo)
+                setLogo(foundLogo.value)
+            }
+            const foundFooterText = variables?.find((v) => v.name === 'BRANDING_FOOTER_TEXT')
+            if (foundFooterText) {
+                setBrandingFooterTextVar(foundFooterText)
+                setFooterText(foundFooterText.value)
+            }
+            const foundFooterLink = variables?.find((v) => v.name === 'BRANDING_FOOTER_LINK')
+            if (foundFooterLink) {
+                setBrandingFooterLinkVar(foundFooterLink)
+                setFooterLink(foundFooterLink.value)
             }
         }
     }, [getAllVariablesApi.data])
@@ -54,11 +68,25 @@ const Branding = () => {
 
     const saveBranding = async () => {
         try {
-            const obj = { name: 'BRANDING_LOGO', value: logo, type: 'static' }
+            const logoObj = { name: 'BRANDING_LOGO', value: logo, type: 'static' }
             if (brandingVar) {
-                await variablesApi.updateVariable(brandingVar.id, obj)
-            } else {
-                await variablesApi.createVariable(obj)
+                await variablesApi.updateVariable(brandingVar.id, logoObj)
+            } else if (logo) {
+                await variablesApi.createVariable(logoObj)
+            }
+
+            const footerTextObj = { name: 'BRANDING_FOOTER_TEXT', value: footerText, type: 'static' }
+            if (brandingFooterTextVar) {
+                await variablesApi.updateVariable(brandingFooterTextVar.id, footerTextObj)
+            } else if (footerText) {
+                await variablesApi.createVariable(footerTextObj)
+            }
+
+            const footerLinkObj = { name: 'BRANDING_FOOTER_LINK', value: footerLink, type: 'static' }
+            if (brandingFooterLinkVar) {
+                await variablesApi.updateVariable(brandingFooterLinkVar.id, footerLinkObj)
+            } else if (footerLink) {
+                await variablesApi.createVariable(footerLinkObj)
             }
             enqueueSnackbar({
                 message: 'Branding saved',
@@ -100,7 +128,17 @@ const Branding = () => {
                         <img src={logo} alt='branding logo' style={{ height: 60, marginTop: 8 }} />
                     </Box>
                 )}
-                <Button variant='contained' sx={{ width: 'fit-content' }} onClick={saveBranding} disabled={!logo}>
+                <OutlinedInput
+                    placeholder='Footer Text'
+                    value={footerText}
+                    onChange={(e) => setFooterText(e.target.value)}
+                />
+                <OutlinedInput
+                    placeholder='Footer Link'
+                    value={footerLink}
+                    onChange={(e) => setFooterLink(e.target.value)}
+                />
+                <Button variant='contained' sx={{ width: 'fit-content' }} onClick={saveBranding} disabled={!logo && !footerText && !footerLink}>
                     Save
                 </Button>
             </Box>

--- a/packages/ui/src/views/chatflows/EmbedChat.jsx
+++ b/packages/ui/src/views/chatflows/EmbedChat.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import { Tabs, Tab, Box } from '@mui/material'
+import { useConfig } from '@/store/context/ConfigContext'
 import { CopyBlock, atomOneDark } from 'react-code-blocks'
 
 // Project import
@@ -176,6 +177,13 @@ export const defaultThemeConfig = {
     }
 }
 
+const buildThemeConfig = (config) => {
+    const theme = JSON.parse(JSON.stringify(defaultThemeConfig))
+    if (config?.BRANDING_FOOTER_TEXT) theme.chatWindow.footer.text = config.BRANDING_FOOTER_TEXT
+    if (config?.BRANDING_FOOTER_LINK) theme.chatWindow.footer.companyLink = config.BRANDING_FOOTER_LINK
+    return theme
+}
+
 const customStringify = (obj) => {
     let stringified = JSON.stringify(obj, null, 4)
         .replace(/"([^"]+)":/g, '$1:')
@@ -191,7 +199,7 @@ const customStringify = (obj) => {
         .join('\n')
 }
 
-const embedPopupHtmlCodeCustomization = (chatflowid) => {
+const embedPopupHtmlCodeCustomization = (chatflowid, themeConfig) => {
     return `<script type="module">
     import Chatbot from "https://cdn.jsdelivr.net/npm/flowise-embed/dist/web.js"
     Chatbot.init({
@@ -203,12 +211,12 @@ const embedPopupHtmlCodeCustomization = (chatflowid) => {
         observersConfig: {
             /* Observers Config */
         },
-        theme: ${customStringify(defaultThemeConfig)}
+        theme: ${customStringify(themeConfig)}
     })
 </script>`
 }
 
-const embedPopupReactCodeCustomization = (chatflowid) => {
+const embedPopupReactCodeCustomization = (chatflowid, themeConfig) => {
     return `import { BubbleChat } from 'flowise-embed-react'
 
 const App = () => {
@@ -222,7 +230,7 @@ const App = () => {
             observersConfig={{
                 /* Observers Config */
             }}
-            theme={{${customStringify(defaultThemeConfig)
+            theme={{${customStringify(themeConfig)
                 .substring(1)
                 .split('\n')
                 .map((line) => ' '.repeat(4) + line)
@@ -232,18 +240,18 @@ const App = () => {
 }`
 }
 
-const getFullPageThemeConfig = () => {
+const getFullPageThemeConfig = (themeConfig) => {
     return {
-        ...defaultThemeConfig,
+        ...themeConfig,
         chatWindow: {
-            ...defaultThemeConfig.chatWindow,
+            ...themeConfig.chatWindow,
             height: '100%',
             width: '100%'
         }
     }
 }
 
-const embedFullpageHtmlCodeCustomization = (chatflowid) => {
+const embedFullpageHtmlCodeCustomization = (chatflowid, themeConfig) => {
     return `<flowise-fullchatbot></flowise-fullchatbot>
 <script type="module">
     import Chatbot from "https://cdn.jsdelivr.net/npm/flowise-embed/dist/web.js"
@@ -256,12 +264,12 @@ const embedFullpageHtmlCodeCustomization = (chatflowid) => {
         observersConfig: {
             /* Observers Config */
         },
-        theme: ${customStringify(getFullPageThemeConfig())}
+        theme: ${customStringify(getFullPageThemeConfig(themeConfig))}
     })
 </script>`
 }
 
-const embedFullpageReactCodeCustomization = (chatflowid) => {
+const embedFullpageReactCodeCustomization = (chatflowid, themeConfig) => {
     return `import { FullPageChat } from 'flowise-embed-react'
 
 const App = () => {
@@ -275,7 +283,7 @@ const App = () => {
             observersConfig={{
                 /* Observers Config */
             }}
-            theme={{${customStringify(getFullPageThemeConfig())
+            theme={{${customStringify(getFullPageThemeConfig(themeConfig))
                 .substring(1)
                 .split('\n')
                 .map((line) => ' '.repeat(4) + line)
@@ -286,6 +294,8 @@ const App = () => {
 }
 
 const EmbedChat = ({ chatflowid }) => {
+    const { config } = useConfig()
+    const themeConfig = buildThemeConfig(config)
     const codes = ['Popup Html', 'Fullpage Html', 'Popup React', 'Fullpage React']
     const [value, setValue] = useState(0)
     const [embedChatCheckboxVal, setEmbedChatCheckbox] = useState(false)
@@ -316,15 +326,15 @@ const EmbedChat = ({ chatflowid }) => {
     const getCodeCustomization = (codeLang) => {
         switch (codeLang) {
             case 'Popup Html':
-                return embedPopupHtmlCodeCustomization(chatflowid)
+                return embedPopupHtmlCodeCustomization(chatflowid, themeConfig)
             case 'Fullpage Html':
-                return embedFullpageHtmlCodeCustomization(chatflowid)
+                return embedFullpageHtmlCodeCustomization(chatflowid, themeConfig)
             case 'Popup React':
-                return embedPopupReactCodeCustomization(chatflowid)
+                return embedPopupReactCodeCustomization(chatflowid, themeConfig)
             case 'Fullpage React':
-                return embedFullpageReactCodeCustomization(chatflowid)
+                return embedFullpageReactCodeCustomization(chatflowid, themeConfig)
             default:
-                return embedPopupHtmlCodeCustomization(chatflowid)
+                return embedPopupHtmlCodeCustomization(chatflowid, themeConfig)
         }
     }
 

--- a/packages/ui/src/views/chatflows/ShareChatbot.jsx
+++ b/packages/ui/src/views/chatflows/ShareChatbot.jsx
@@ -5,6 +5,7 @@ import { SketchPicker } from 'react-color'
 import PropTypes from 'prop-types'
 
 import { Card, Box, Typography, Button, Switch, OutlinedInput, Popover, Stack, IconButton } from '@mui/material'
+import { useConfig } from '@/store/context/ConfigContext'
 import { useTheme } from '@mui/material/styles'
 
 // Project import
@@ -47,9 +48,19 @@ const defaultConfig = {
     }
 }
 
+const buildDefaultConfig = (config) => {
+    return {
+        ...defaultConfig,
+        poweredByText: config?.BRANDING_FOOTER_TEXT || defaultConfig.poweredByText,
+        poweredByLink: config?.BRANDING_FOOTER_LINK || defaultConfig.poweredByLink
+    }
+}
+
 const ShareChatbot = ({ isSessionMemory, isAgentCanvas }) => {
     const dispatch = useDispatch()
     const theme = useTheme()
+    const { config } = useConfig()
+    const defaultValues = buildDefaultConfig(config)
     const chatflow = useSelector((state) => state.canvas.chatflow)
     const chatflowid = chatflow.id
     const chatbotConfig = chatflow.chatbotConfig ? JSON.parse(chatflow.chatbotConfig) : {}
@@ -72,11 +83,11 @@ const ShareChatbot = ({ isSessionMemory, isAgentCanvas }) => {
 
     const [welcomeMessage, setWelcomeMessage] = useState(chatbotConfig?.welcomeMessage ?? '')
     const [errorMessage, setErrorMessage] = useState(chatbotConfig?.errorMessage ?? '')
-    const [backgroundColor, setBackgroundColor] = useState(chatbotConfig?.backgroundColor ?? defaultConfig.backgroundColor)
-    const [fontSize, setFontSize] = useState(chatbotConfig?.fontSize ?? defaultConfig.fontSize)
-    const [poweredByTextColor, setPoweredByTextColor] = useState(chatbotConfig?.poweredByTextColor ?? defaultConfig.poweredByTextColor)
-    const [poweredByText, setPoweredByText] = useState(chatbotConfig?.poweredByText ?? defaultConfig.poweredByText)
-    const [poweredByLink, setPoweredByLink] = useState(chatbotConfig?.poweredByLink ?? defaultConfig.poweredByLink)
+    const [backgroundColor, setBackgroundColor] = useState(chatbotConfig?.backgroundColor ?? defaultValues.backgroundColor)
+    const [fontSize, setFontSize] = useState(chatbotConfig?.fontSize ?? defaultValues.fontSize)
+    const [poweredByTextColor, setPoweredByTextColor] = useState(chatbotConfig?.poweredByTextColor ?? defaultValues.poweredByTextColor)
+    const [poweredByText, setPoweredByText] = useState(chatbotConfig?.poweredByText ?? defaultValues.poweredByText)
+    const [poweredByLink, setPoweredByLink] = useState(chatbotConfig?.poweredByLink ?? defaultValues.poweredByLink)
 
     const getShowAgentMessagesStatus = () => {
         if (chatbotConfig?.showAgentMessages !== undefined) {


### PR DESCRIPTION
## Summary
- allow configuring footer branding in settings API
- enable editing footer text and link on Branding page
- use new footer config in embed code and share chatbot defaults

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f67daa14c8327bc4e7bc79fda92ef