### PR TITLE
Fix branding footer refresh

### DIFF
--- a/packages/ui/src/views/branding/index.jsx
+++ b/packages/ui/src/views/branding/index.jsx
@@ -12,9 +12,11 @@ import useApi from '@/hooks/useApi'
 import useNotifier from '@/utils/useNotifier'
 
 import { IconX } from '@tabler/icons-react'
+import { useConfig } from '@/store/context/ConfigContext'
 
 const Branding = () => {
     const dispatch = useDispatch()
+    const { refreshConfig } = useConfig()
     useNotifier()
 
     const enqueueSnackbar = (...args) => dispatch(enqueueSnackbarAction(...args))
@@ -88,6 +90,8 @@ const Branding = () => {
             } else if (footerLink) {
                 await variablesApi.createVariable(footerLinkObj)
             }
+
+            refreshConfig()
             enqueueSnackbar({
                 message: 'Branding saved',
                 options: {


### PR DESCRIPTION
## Summary
- expose `refreshConfig` in ConfigContext
- reload config after updating Branding settings to show new footer

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6e534dd8832785237122d005bd61