### PR TITLE
Fix branding footer refresh

### DIFF
--- a/packages/ui/src/views/branding/index.jsx
+++ b/packages/ui/src/views/branding/index.jsx
@@ -12,9 +12,11 @@ import useApi from '@/hooks/useApi'
 import useNotifier from '@/utils/useNotifier'
 
 import { IconX } from '@tabler/icons-react'
+import { useConfig } from '@/store/context/ConfigContext'
 
 const Branding = () => {
     const dispatch = useDispatch()
+    const { refreshConfig } = useConfig()
     useNotifier()
 
     const enqueueSnackbar = (...args) => dispatch(enqueueSnackbarAction(...args))
@@ -88,6 +90,8 @@ const Branding = () => {
             } else if (footerLink) {
                 await variablesApi.createVariable(footerLinkObj)
             }
+
+            refreshConfig()
             enqueueSnackbar({
                 message: 'Branding saved',
                 options: {

--- a/packages/ui/src/views/branding/index.jsx
+++ b/packages/ui/src/views/branding/index.jsx
@@ -145,6 +145,10 @@ const Branding = () => {
                 <Button variant='contained' sx={{ width: 'fit-content' }} onClick={saveBranding} disabled={!logo && !footerText && !footerLink}>
                     Save
                 </Button>
+                <Typography variant='body2' sx={{ mt: 2 }}>
+                    The footer is completely configurable through the <code>theme.chatWindow.footer</code> object.
+                    Add or override this block inside the snippet where you call the chatbot widget.
+                </Typography>
             </Box>
         </MainCard>
     )

--- a/packages/ui/src/views/chatbot/index.jsx
+++ b/packages/ui/src/views/chatbot/index.jsx
@@ -6,6 +6,7 @@ import chatflowsApi from '@/api/chatflows'
 
 // Hooks
 import useApi from '@/hooks/useApi'
+import { useConfig } from '@/store/context/ConfigContext'
 
 // MUI
 import { Box, Card, Stack, Typography, useTheme } from '@mui/material'
@@ -21,6 +22,7 @@ const ChatbotFull = () => {
     const URLpath = document.location.pathname.toString().split('/')
     const chatflowId = URLpath[URLpath.length - 1] === 'chatbot' ? '' : URLpath[URLpath.length - 1]
     const theme = useTheme()
+    const { config } = useConfig()
 
     const [chatflow, setChatflow] = useState(null)
     const [chatbotTheme, setChatbotTheme] = useState({})
@@ -50,6 +52,12 @@ const ChatbotFull = () => {
 
                 try {
                     parsedConfig = { ...parsedConfig, ...JSON.parse(chatflowData.chatbotConfig) }
+                    if (!parsedConfig.poweredByText && config?.BRANDING_FOOTER_TEXT) {
+                        parsedConfig.poweredByText = config.BRANDING_FOOTER_TEXT
+                    }
+                    if (!parsedConfig.poweredByLink && config?.BRANDING_FOOTER_LINK) {
+                        parsedConfig.poweredByLink = config.BRANDING_FOOTER_LINK
+                    }
                     setChatbotTheme(parsedConfig)
                     if (parsedConfig.overrideConfig) {
                         setChatbotOverrideConfig(parsedConfig.overrideConfig)
@@ -60,14 +68,26 @@ const ChatbotFull = () => {
                     }
                 } catch (e) {
                     console.error(e)
+                    if (!parsedConfig.poweredByText && config?.BRANDING_FOOTER_TEXT) {
+                        parsedConfig.poweredByText = config.BRANDING_FOOTER_TEXT
+                    }
+                    if (!parsedConfig.poweredByLink && config?.BRANDING_FOOTER_LINK) {
+                        parsedConfig.poweredByLink = config.BRANDING_FOOTER_LINK
+                    }
                     setChatbotTheme(parsedConfig)
                     setChatbotOverrideConfig({})
                 }
-            } else if (chatflowType === 'MULTIAGENT' || chatflowType === 'AGENTFLOW') {
-                setChatbotTheme({ showAgentMessages: true })
+            } else {
+                const baseTheme = {}
+                if (chatflowType === 'MULTIAGENT' || chatflowType === 'AGENTFLOW') {
+                    baseTheme.showAgentMessages = true
+                }
+                if (config?.BRANDING_FOOTER_TEXT) baseTheme.poweredByText = config.BRANDING_FOOTER_TEXT
+                if (config?.BRANDING_FOOTER_LINK) baseTheme.poweredByLink = config.BRANDING_FOOTER_LINK
+                setChatbotTheme(baseTheme)
             }
         }
-    }, [getSpecificChatflowFromPublicApi.data, getSpecificChatflowApi.data])
+    }, [getSpecificChatflowFromPublicApi.data, getSpecificChatflowApi.data, config])
 
     useEffect(() => {
         setLoading(getSpecificChatflowFromPublicApi.loading || getSpecificChatflowApi.loading)


### PR DESCRIPTION
## Summary
- expose `refreshConfig` in ConfigContext
- reload config after updating Branding settings to show new footer
- use branding defaults when loading public chatbot
- apply branding defaults if chatflow lacks config

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test` *(fails: turbo not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687f6e534dd8832785237122d005bd61